### PR TITLE
Storage.__init__ can accept an Elasticsearch instance

### DIFF
--- a/tableschema_elasticsearch/storage.py
+++ b/tableschema_elasticsearch/storage.py
@@ -18,9 +18,9 @@ from . import mappers
 # Module API
 
 class Storage(object):
-    """SQL Tabular Storage.
+    """Elasticsearch Tabular Storage.
 
-    It's an implementation of `jsontablescema.Storage`.
+    It's an implementation of `tableschema.Storage`.
 
     Args:
         es (object): ElasticSearch instance
@@ -28,19 +28,14 @@ class Storage(object):
 
     # Public
 
-    def __init__(self, es):
-
-        # Set attributes
-        self.__es = Elasticsearch()
+    def __init__(self, es=None):
+        # Use the passed `es` or create a new Elasticsearch instance
+        self.__es = es if es is not None else Elasticsearch()
 
     def __repr__(self):
-
         # Template and format
-        template = 'Storage <{engine}>'
-        text = template.format(
-            engine=self.__es
-        )
-
+        template = 'Storage {engine}'
+        text = template.format(engine=self.__es)
         return text
 
     @property

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -4,8 +4,8 @@ from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+import six
 import json
-import pytest
 import io
 from tabulator import Stream
 from elasticsearch import Elasticsearch
@@ -65,3 +65,17 @@ def test_storage():
 
     # Delete buckets
     storage.delete()
+
+
+def test_es_instance():
+    '''An Elasticsearch instance can be passed to Storage or will be created'''
+    storage = Storage()
+    assert repr(storage) == "Storage <Elasticsearch([{}])>"
+
+    es = Elasticsearch(['localhost'])
+    storage = Storage(es)
+
+    if six.PY2:
+        assert repr(storage) == "Storage <Elasticsearch([{u'host': u'localhost'}])>"
+    else:
+        assert repr(storage) == "Storage <Elasticsearch([{'host': 'localhost'}])>"


### PR DESCRIPTION
- fixes #3 

---

An Elasticsearch instance can be passed as an arg to `Storage()`. If none is provided, one will be created in `__init__`.